### PR TITLE
Adding full and half cell geometries and refactoring `bfacemask!`

### DIFF
--- a/packages/JuliaMPBSolver/test/runtests.jl
+++ b/packages/JuliaMPBSolver/test/runtests.jl
@@ -6,9 +6,14 @@ using Test
     @test JuliaMPBSolver.Units.RT(0) == 0
   end
   @testset "Grids" begin
-    grid = JuliaMPBSolver.Grid.create_grid(
+    grid = JuliaMPBSolver.Grid.create_full_cell(
       JuliaMPBSolver.Grid.GeometricGrid(10.0f0, 0, 1.0f0, 1.0f0, false),
     )
     @test JuliaMPBSolver.Grid.is_equivalent(grid, 1, 11, 10, 3)
+
+    grid = JuliaMPBSolver.Grid.create_half_cell(
+      JuliaMPBSolver.Grid.GeometricGrid(10.0f0, 0, 1.0f0, 1.0f0, false),
+    )
+    @test JuliaMPBSolver.Grid.is_equivalent(grid, 1, 11, 10, 2)
   end
 end


### PR DESCRIPTION
Changed the grid utilities so we can produce the full and half-cell geometries. Also refactored `bfacemask!` to `add_boundary_face!`, which is a little more descriptive for what it does. 

As of now, everything is only written for 1D